### PR TITLE
Partial fix for the Current measurement routines.

### DIFF
--- a/INA228.cpp
+++ b/INA228.cpp
@@ -116,7 +116,7 @@ float INA228::getPower()
 float INA228::getTemperature()
 {
   uint32_t value = _readRegister(INA228_TEMPERATURE, 2);
-  return value * 7.8125e-6;
+  return value * 7.8125e-3;
 }
 
 //  PAGE 26 + 8.1.2


### PR DESCRIPTION
I was finally able to get the correct measurement of the Current.
I've committed changes, which I'm sure are needed.
But this is not enough to fix the measurement issue completely.

**Change 1**: Update for the **getCurrent()**
![image](https://github.com/user-attachments/assets/fc3bca3e-d052-4861-8d9d-8a86680654d1)
- **added** row 98 to read 20 bits
![image](https://github.com/user-attachments/assets/5b263aad-fbd7-4b6b-b44d-68712efcaf47)
- **added** row 110 to return value according to the document

![image](https://github.com/user-attachments/assets/6ddeceef-f2fe-42a8-b149-03835a09c12d)

- **rows** from 100 to 104 are not required in this function and need to be moved to **setMaxCurrentShunt()**, in my opinion.



**Change 2**: Update for the **setMaxCurrentShunt()**
![image](https://github.com/user-attachments/assets/73311db4-d541-471e-88f1-d10862632397)
- **updated row 306** to make it possible to configure Shunt to 0.0002 Om, because in my INA228 module, there is an integrated 0.0002 Om Shunt. This change will make it possible to use the library with such devices as mine.
- **added rows 310-316** as a placeholder for the SHUNT_CAL register routines, like calculations and register updates. 
I've tried to do such calculations here but with no results. 
I was not able to write the calculated SHUNT_CAL value for my configuration using internal _writeRegister().
The default value for the SHUNT_CAL register is 4096, my calculated value is 50, and after _writeRegister() I read 4096.
That is why I moved this part to the Project side to **setup(void)** and used **adafruit/Adafruit BusIO@^1.16.1** library to write to the register calculated value.



**Change 3**: In my project, I've added some routines to **setup(void)** to write SHUNT_CAL register calculated value

```cpp
  INA.reset();

  if (!i2c_dev.begin()) {
    Serial.print("Did not find device at 0x");
    Serial.println(i2c_dev.address(), HEX);
    while (1);
  }

  Adafruit_I2CRegister shunt = Adafruit_I2CRegister(&i2c_dev, 0x02, 2, MSBFIRST);
  int16_t shunt_cal = shunt.read();
  Serial.print("#1: Shunt Calibration: " + String(shunt_cal));
  Serial.print(" - Shunt Calibration (bits): ");
  Serial.println(shunt_cal, BIN);

  float maxCurrent_A = 10;       // Max current in Amps
  float shunt_Om = 0.0002;       // Shunt resistance in Ohms

  INA.setMode(INA228_MODE_CONT_TEMP_BUS_SHUNT);
  INA.setMaxCurrentShunt(maxCurrent_A, shunt_Om);
  INA.setAverage(INA228_16_SAMPLES);

  float current_LSB = maxCurrent_A * pow(2, -19);
  float scale = 1;
  float shunt_cal_calc = 13107.2 * 1000000.0 * shunt_Om * current_LSB * scale;
  uint16_t value = shunt_cal_calc;
  
  Serial.print("#2: Shunt Calibration calc: " + String(value));
  Serial.print(" - Shunt Calibration (bits): ");
  Serial.println(value, BIN);
  shunt.write(value);

  shunt_cal = shunt.read();
  Serial.print("#3: Shunt Calibration: " + String(shunt_cal));
  Serial.print(" - Shunt Calibration (bits): ");
  Serial.println(shunt_cal, BIN);
```
Here is the TERMINAL OUTPUT:
```
INA228 found.
#1: Shunt Calibration: 4096 - Shunt Calibration (bits): 1000000000000
#2: Shunt Calibration calc: 50 - Shunt Calibration (bits): 110010
#3: Shunt Calibration: 50 - Shunt Calibration (bits): 110010     
#4: Temperature (DIETEMP): 2883 - DIETEMP (bits): 101101000011   
#5: Temperature: 22.523438
```


As a Load in my tests, I'm using a precise 126 Om resistor with 0.1% tolerance.
Finally, I was able to get using the INA228 pretty close values to the INA231 results.
![image](https://github.com/user-attachments/assets/7b508ad5-33f9-48c0-b152-c59110939247)





